### PR TITLE
Use toBytesUnits() helper and rename params to 'alignment'

### DIFF
--- a/src/binned_allocator.zig
+++ b/src/binned_allocator.zig
@@ -108,10 +108,9 @@ pub fn BinnedAllocator(comptime config: Config) type {
         ) bool {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = alignment.toByteUnits();
             comptime var prev_size: usize = 0;
             inline for (&self.bins) |*bin| {
-                if (buf.len <= bin.size and align_ <= bin.size) {
+                if (buf.len <= bin.size and alignment.toByteUnits() <= bin.size) {
                     // Check it still fits
                     return new_len > prev_size and new_len <= bin.size;
                 }
@@ -126,9 +125,8 @@ pub fn BinnedAllocator(comptime config: Config) type {
         fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = alignment.toByteUnits();
             inline for (&self.bins) |*bin| {
-                if (buf.len <= bin.size and align_ <= bin.size) {
+                if (buf.len <= bin.size and alignment.toByteUnits() <= bin.size) {
                     bin.free(buf.ptr);
                     return;
                 }

--- a/src/binned_allocator.zig
+++ b/src/binned_allocator.zig
@@ -82,8 +82,7 @@ pub fn BinnedAllocator(comptime config: Config) type {
         ) ?[*]u8 {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = @as(usize, 1) << @intFromEnum(log2_align);
-            const size = @max(len, align_);
+            const size = @max(len, log2_align.toByteUnits());
             inline for (&self.bins) |*bin| {
                 if (size <= bin.size) {
                     return bin.alloc(self.backing_allocator);
@@ -109,7 +108,7 @@ pub fn BinnedAllocator(comptime config: Config) type {
         ) bool {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = @as(usize, 1) << @intFromEnum(log2_align);
+            const align_ = log2_align.toByteUnits();
             comptime var prev_size: usize = 0;
             inline for (&self.bins) |*bin| {
                 if (buf.len <= bin.size and align_ <= bin.size) {
@@ -127,7 +126,7 @@ pub fn BinnedAllocator(comptime config: Config) type {
         fn free(ctx: *anyopaque, buf: []u8, log2_align: std.mem.Alignment, ret_addr: usize) void {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = @as(usize, 1) << @intFromEnum(log2_align);
+            const align_ = log2_align.toByteUnits();
             inline for (&self.bins) |*bin| {
                 if (buf.len <= bin.size and align_ <= bin.size) {
                     bin.free(buf.ptr);

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -106,23 +106,23 @@ pub const FailingAllocator = struct {
     fn alloc(
         ctx: *anyopaque,
         len: usize,
-        log2_ptr_align: std.mem.Alignment,
+        ptr_alignment: std.mem.Alignment,
         return_address: usize,
     ) ?[*]u8 {
         const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
         if (shouldFail(self)) return null;
-        return self.internal_allocator.rawAlloc(len, log2_ptr_align, return_address);
+        return self.internal_allocator.rawAlloc(len, ptr_alignment, return_address);
     }
 
     fn resize(
         ctx: *anyopaque,
         old_mem: []u8,
-        log2_old_align: std.mem.Alignment,
+        old_alignment: std.mem.Alignment,
         new_len: usize,
         ra: usize,
     ) bool {
         const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
-        if (!self.internal_allocator.rawResize(old_mem, log2_old_align, new_len, ra))
+        if (!self.internal_allocator.rawResize(old_mem, old_alignment, new_len, ra))
             return false;
         return true;
     }
@@ -130,11 +130,11 @@ pub const FailingAllocator = struct {
     fn free(
         ctx: *anyopaque,
         old_mem: []u8,
-        log2_old_align: std.mem.Alignment,
+        old_alignment: std.mem.Alignment,
         ra: usize,
     ) void {
         const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
-        self.internal_allocator.rawFree(old_mem, log2_old_align, ra);
+        self.internal_allocator.rawFree(old_mem, old_alignment, ra);
     }
 
     fn remap(


### PR DESCRIPTION
Adds suggestions from zigtools/zls#2179 

- Use std.mem.Alignment toByteUnits() helper
- Rename log2_ params in allocators to alignment
- Delete intermediate variable align_

Build tested in neovim
All unit tests passed on x86_64 linux with 

```bash
zig test src/binned_allocator.zig
```

Feel free to cherry pick if you do not want all 3 changes